### PR TITLE
add environment variable collection behind -parseEnv flag

### DIFF
--- a/App/ProcessMonitor/main.h
+++ b/App/ProcessMonitor/main.h
@@ -22,6 +22,9 @@ NSString* filterBy = nil;
 //'prettyPrint' flag
 BOOL prettyPrint = NO;
 
+//'parseEnv' flag to capture environment variable information
+BOOL parseEnv = NO;
+ 
 /* FUNCTIONS */
 
 //process args

--- a/App/ProcessMonitor/main.m
+++ b/App/ProcessMonitor/main.m
@@ -87,6 +87,9 @@ BOOL processArgs(NSArray* arguments)
     //init 'prettyPrint' flag
     prettyPrint = [arguments containsObject:@"-pretty"];
     
+    //init 'parseEnv' flag
+    parseEnv = [arguments containsObject:@"-parseEnv"];
+    
     //extract value for 'filterBy'
     index = [arguments indexOfObject:@"-filter"];
     if(NSNotFound != index)
@@ -134,6 +137,7 @@ void usage()
     printf(" -h or -help      display this usage info\n");
     printf(" -pretty          JSON output is 'pretty-printed'\n");
     printf(" -skipApple       ignore Apple (platform) processes \n");
+    printf(" -parseEnv        parse environment variable information\n");
     printf(" -filter <name>   show events matching process name\n\n");
     
     return;
@@ -191,7 +195,7 @@ BOOL monitor()
         
     //start monitoring
     // pass in events, count, and callback block for events
-    return [procMon start:events count:sizeof(events)/sizeof(events[0]) csOption:csStatic callback:block];
+    return [procMon start:events count:sizeof(events)/sizeof(events[0]) csOption:csStatic parseEnv:parseEnv callback:block];
 }
 
 //prettify JSON

--- a/Library/Source/ProcessMonitor.h
+++ b/Library/Source/ProcessMonitor.h
@@ -41,8 +41,8 @@ typedef void (^ProcessCallbackBlock)(Process* _Nonnull);
 @interface ProcessMonitor : NSObject
 
 //start monitoring
-// pass in events of interest, count of said events, flag for codesigning, and callback
--(BOOL)start:(es_event_type_t* _Nonnull)events count:(uint32_t)count csOption:(NSUInteger)csOption callback:(ProcessCallbackBlock _Nonnull)callback;
+// pass in events of interest, count of said events, flag for codesigning, flag for environment variable collection, and callback
+-(BOOL)start:(es_event_type_t* _Nonnull)events count:(uint32_t)count csOption:(NSUInteger)csOption parseEnv:(BOOL)parseEnv callback:(ProcessCallbackBlock _Nonnull)callback;
 
 //stop monitoring
 -(BOOL)stop;
@@ -89,6 +89,9 @@ typedef void (^ProcessCallbackBlock)(Process* _Nonnull);
 //args
 @property(nonatomic, retain)NSMutableArray* _Nonnull arguments;
 
+//environment variables
+@property(nonatomic, retain)NSMutableDictionary* _Nonnull environment;
+
 //ancestors
 @property(nonatomic, retain)NSMutableArray* _Nonnull ancestors;
 
@@ -118,6 +121,6 @@ typedef void (^ProcessCallbackBlock)(Process* _Nonnull);
 
 //init
 // flag controls code signing options
--(id _Nullable)init:(es_message_t* _Nonnull)message csOption:(NSUInteger)csOption;
+-(id _Nullable)init:(es_message_t* _Nonnull)message csOption:(NSUInteger)csOption parseEnv:(BOOL)parseEnv;
 
 @end

--- a/Library/Source/ProcessMonitor.m
+++ b/Library/Source/ProcessMonitor.m
@@ -25,8 +25,8 @@ pid_t (*getRPID)(pid_t pid) = NULL;
 @implementation ProcessMonitor
 
 //start monitoring
-// pass in events of interest, count of said events, flag for codesigning, and callback
--(BOOL)start:(es_event_type_t*)events count:(uint32_t)count csOption:(NSUInteger)csOption callback:(ProcessCallbackBlock)callback
+// pass in events of interest, count of said events, flag for codesigning, flag for environment variable collection, and callback
+-(BOOL)start:(es_event_type_t*)events count:(uint32_t)count csOption:(NSUInteger)csOption parseEnv:(BOOL)parseEnv callback:(ProcessCallbackBlock)callback
 {
     //flag
     BOOL started = NO;
@@ -47,7 +47,7 @@ pid_t (*getRPID)(pid_t pid) = NULL;
         
         //init process obj
         // do static check as well
-        process = [[Process alloc] init:(es_message_t* _Nonnull)message csOption:csOption];
+        process = [[Process alloc] init:(es_message_t* _Nonnull)message csOption:csOption parseEnv:parseEnv];
         if(nil != process)
         {
             //invoke user callback

--- a/Library/Source/utilities.h
+++ b/Library/Source/utilities.h
@@ -14,5 +14,7 @@
 
 //convert es_string_token_t to string
 NSString* convertStringToken(es_string_token_t* stringToken);
+//convert environment variable string to two separate strings representing a key and a value
+void convertEnvironmentVariableStringToKeyValue(NSString *env, NSString **key, NSString **value);
 
 #endif /* utilities_h */

--- a/Library/Source/utilities.m
+++ b/Library/Source/utilities.m
@@ -30,3 +30,36 @@ bail:
     
     return string;
 }
+
+// parses environment string |env| and writes the key to |key| and the value to |value|
+void convertEnvironmentVariableStringToKeyValue(NSString *env, NSString **key, NSString **value)
+{
+    NSRange firstEquals = [env rangeOfString:@"="];
+    if(firstEquals.length == NSNotFound)
+    {
+        return;
+    }
+    
+    @try
+    {
+        NSString *keySubStr = [env substringToIndex:firstEquals.location];
+        if(keySubStr != nil && keySubStr.length > 0)
+        {
+            *key = keySubStr;
+        }
+        else
+        {
+            // key cannot be empty, fail fast
+            return;
+        }
+        
+        NSString *valueSubStr = [env substringFromIndex:firstEquals.location + 1];
+        // either empty or contains value, either is fine
+        *value = valueSubStr;
+    }
+    // should never happen but just in case
+    @catch (NSException *exception)
+    {
+        return;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It captures process `start`, `fork`, and `exit` events, providing:
 * path
 * ancestory
 * arguments
+* environment variables
 * code-signing information
 
 **Read More:** \


### PR DESCRIPTION
Hey there! This PR adds environment variable information to Process Monitor for process execution events. It uses [es_exec_env()](https://developer.apple.com/documentation/endpointsecurity/3259703-es_exec_env?changes=latest_minor) on `es_event_exec_t` events to extract the environment variable string and parse it into separate key & value strings, finally building an object out of them. Also, I put the feature behind the `-parseEnv` flag for backwards compatibility, just in case. Please let me know if there are any additional changes you would like, cheers!

Sample output:
```
{
   "event":"ES_EVENT_TYPE_NOTIFY_EXEC",
   "timestamp":"2021-06-16 05:57:13 +0000",
   "process":{
      "pid":3841,
      "name":"sleep",
      "path":"/bin/sleep",
      "uid":501,
      "architecture":"Apple Silicon",
      "arguments":[
         "sleep",
         "5"
      ],
      "environment":{
         "TERM_SESSION_ID":"568A9417-78DB-460B-B0FA-B4222C12C917",
         "SSH_AUTH_SOCK":"/private/tmp/com.apple.launchd.1Shd6INeXx/Listeners",
         "OLDPWD":"/Users/rwx",
         "XPC_FLAGS":"0x0",
         "LANG":"en_CA.UTF-8",
         "PWD":"/Users/rwx",
         "SHELL":"/bin/zsh"
      },
      "ppid":700,
      "rpid":619,
      "ancestors":[
         619,
         1
      ],
      "signing info (reported)":{
         "csFlags":570492929,
         "platformBinary":1,
         "signingID":"com.apple.sleep",
         "teamID":"",
         "cdHash":"184D976B4D71ADFDE64B76999FC3C55B27D2BAD3"
      },
      "signing info (computed)":{
         "signatureID":"com.apple.sleep",
         "signatureStatus":0,
         "signatureSigner":"Apple",
         "signatureAuthorities":[
            "Software Signing",
            "Apple Code Signing Certification Authority",
            "Apple Root CA"
         ]
      }
   }
}
```