### PR TITLE
Add -compact mode for printing CLI like invocations

### DIFF
--- a/App/ProcessMonitor/main.h
+++ b/App/ProcessMonitor/main.h
@@ -13,7 +13,7 @@
 
 /* GLOBALS */
 
-//'skipAPple' flag
+//'skipApple' flag
 BOOL skipApple = NO;
 
 //filter string
@@ -21,6 +21,9 @@ NSString* filterBy = nil;
 
 //'prettyPrint' flag
 BOOL prettyPrint = NO;
+
+//'compact' flag
+BOOL compact = NO;
 
 //'parseEnv' flag to capture environment variable information
 BOOL parseEnv = NO;

--- a/App/ProcessMonitor/main.m
+++ b/App/ProcessMonitor/main.m
@@ -86,6 +86,9 @@ BOOL processArgs(NSArray* arguments)
     
     //init 'prettyPrint' flag
     prettyPrint = [arguments containsObject:@"-pretty"];
+
+    //init 'compact' flag
+    compact = [arguments containsObject:@"-compact"];
     
     //init 'parseEnv' flag
     parseEnv = [arguments containsObject:@"-parseEnv"];
@@ -136,6 +139,7 @@ void usage()
     printf("\n%s (v%s) usage:\n", name.UTF8String, version.UTF8String);
     printf(" -h or -help      display this usage info\n");
     printf(" -pretty          JSON output is 'pretty-printed'\n");
+    printf(" -compact         output is printed on a single line imitating a command line invocation\n");
     printf(" -skipApple       ignore Apple (platform) processes \n");
     printf(" -parseEnv        parse environment variable information\n");
     printf(" -filter <name>   show events matching process name\n\n");
@@ -179,12 +183,16 @@ BOOL monitor()
                 return;
             }
         }
-    
+
         //pretty print?
         if(YES == prettyPrint)
         {
             //make me pretty!
             printf("%s\n", prettifyJSON(process.description).UTF8String);
+        }
+        else if(YES == compact)
+        {
+            printf("%s\n", process.compactDescription.UTF8String);
         }
         else
         {

--- a/Library/Release/ProcessMonitor.h
+++ b/Library/Release/ProcessMonitor.h
@@ -120,4 +120,6 @@ typedef void (^ProcessCallbackBlock)(Process* _Nonnull);
 // flag controls code signing options
 -(id _Nullable)init:(es_message_t* _Nonnull)message csOption:(NSUInteger)csOption;
 
+-(NSString* _Nonnull)compactDescription;
+
 @end

--- a/Library/Source/Process.m
+++ b/Library/Source/Process.m
@@ -820,6 +820,17 @@ bail:
     return description;
 }
 
+-(NSString *)compactDescription {
+    if (self.arguments.count < 1) {
+        return self.path;
+    }
+
+    NSArray<NSString*>* arguments = @[self.path];
+    arguments = [arguments arrayByAddingObjectsFromArray:
+                 [self.arguments subarrayWithRange:NSMakeRange(1, self.arguments.count - 1)]];
+    return [arguments componentsJoinedByString:@" "];
+}
+
 @end
 
 //helper function

--- a/Library/Source/ProcessMonitor.h
+++ b/Library/Source/ProcessMonitor.h
@@ -123,4 +123,6 @@ typedef void (^ProcessCallbackBlock)(Process* _Nonnull);
 // flag controls code signing options
 -(id _Nullable)init:(es_message_t* _Nonnull)message csOption:(NSUInteger)csOption parseEnv:(BOOL)parseEnv;
 
+-(NSString* _Nonnull)compactDescription;
+
 @end


### PR DESCRIPTION
This is useful for compact viewing as if you had run each command from the command line. I think this is more glanceable and grep-able when you're investigating specific commands.